### PR TITLE
Warn user if revocation list missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,16 +25,10 @@ func main() {
 
 	// check revocation list
 	revList := path.Join(os.Getenv("HOME"), ".pwget2-revocation")
-	_, err = os.Stat(revList)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// warn user (on stderr so it doesn't get piped into xsel)
-			os.Stderr.Write([]byte("Warning: Revocation list list not found" +
-				" (expected in " + revList + ")\n"))
-		} else {
-			// fail only if stat failed but revocation list file is present
-			panic(err)
-		}
+	if _, err = os.Stat(revList); err != nil {
+		// warn user (on stderr so it doesn't get piped into xsel)
+		os.Stderr.Write([]byte("Warning: Revocation list missing or not readable" +
+			" (expected in " + revList + ")\n"))
 	}
 
 	// call pwget

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/tilinna/z85"
@@ -14,7 +15,7 @@ import (
 
 func main() {
 	// print commit of build
-	// print to stderr so that it doesn't get piped into xsel
+	// write to stderr so that it doesn't get piped into xsel
 	os.Stderr.Write([]byte("xkcdget build: " + buildCommit() + "\n"))
 
 	// find pwget
@@ -22,6 +23,21 @@ func main() {
 	pwgetExe, err := exec.LookPath(pwgetName)
 	failOnError(err, "Finding "+pwgetName+" on your system failed")
 
+	// check revocation list
+	revList := path.Join(os.Getenv("HOME"), ".pwget2-revocation")
+	_, err = os.Stat(revList)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// warn user (on stderr so it doesn't get piped into xsel)
+			os.Stderr.Write([]byte("Warning: Revocation list list not found" +
+				" (expected in " + revList + ")\n"))
+		} else {
+			// fail only if stat failed but revocation list file is present
+			panic(err)
+		}
+	}
+
+	// call pwget
 	pwgetCmd := exec.Command(pwgetExe, os.Args[1:]...)
 	pwgetCmd.Stdin = os.Stdin
 	pwgetCmd.Stderr = os.Stderr


### PR DESCRIPTION
With my revocation list steadily growing, I now have to make sure to have it on each of my systems.
But sometimes I forgot to sync it. So let xkcdget remind me if it's missing.

@majewsky Maybe you'd like to include this into pwget.